### PR TITLE
fix: camera draw over ui and allow moving

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/CameraSensor.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/CameraSensor.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &683421532908195521
+--- !u!1 &7800869322880189811
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,9 +8,108 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8618870265807608092}
-  - component: {fileID: 1748890876559847002}
-  - component: {fileID: 4817441929433844819}
+  - component: {fileID: 7800869322880189814}
+  - component: {fileID: 7800869322880189800}
+  - component: {fileID: 7800869322880189815}
+  - component: {fileID: 6839870103089997461}
+  m_Layer: 0
+  m_Name: CameraSensor
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7800869322880189814
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7800869322880189811}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4870202455082481488}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7800869322880189800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7800869322880189811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c65d1fdc35027290e9b91e2c6ecab1fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  imageOnGui:
+    show: 1
+    xOffset: 0
+    yOffset: 0
+    height: 0
+  cameraParameters:
+    width: 1920
+    height: 1080
+    fx: 0
+    fy: 0
+    cx: 0
+    cy: 0
+    k1: 0
+    k2: 0
+    p1: 0
+    p2: 0
+    k3: 0
+  cameraObject: {fileID: 0}
+  distortionShader: {fileID: 7200000, guid: 8ba118ba5fd3df74da56fc7b5c68f16c, type: 3}
+  rosImageShader: {fileID: 7200000, guid: ec3733322406d6750a0ad58713c14110, type: 3}
+--- !u!114 &7800869322880189815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7800869322880189811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ecaa6f04f76012cce9743315c68a4a83, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  imageTopic: /sensing/camera/traffic_light/image_raw
+  cameraInfoTopic: /sensing/camera/traffic_light/camera_info
+  frameId: traffic_light_left_camera/camera_optical_link
+  qosSettings:
+    ReliabilityPolicy: 2
+    DurabilityPolicy: 2
+    HistoryPolicy: 1
+    Depth: 1
+--- !u!114 &6839870103089997461
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7800869322880189811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0883c4f62730bd4c90ee9fc4a26c0c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraOutputCanvas: {fileID: 0}
+--- !u!1 &8949463558098794085
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4870202455082481488}
+  - component: {fileID: 4375637830271308160}
+  - component: {fileID: 1948158105520983295}
   m_Layer: 0
   m_Name: CameraObject
   m_TagString: Untagged
@@ -18,27 +117,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &8618870265807608092
+--- !u!4 &4870202455082481488
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 683421532908195521}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 8949463558098794085}
+  m_LocalRotation: {x: -5.551115e-17, y: -0.0000000074505797, z: 1.8917487e-10, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7800869322880189814}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!20 &1748890876559847002
+--- !u!20 &4375637830271308160
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 683421532908195521}
+  m_GameObject: {fileID: 8949463558098794085}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -75,203 +174,35 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &4817441929433844819
+--- !u!114 &1948158105520983295
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 683421532908195521}
+  m_GameObject: {fileID: 8949463558098794085}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Version: 7
-  m_ObsoleteRenderingPath: 0
-  m_ObsoleteFrameSettings:
-    overrides: 0
-    enableShadow: 0
-    enableContactShadows: 0
-    enableShadowMask: 0
-    enableSSR: 0
-    enableSSAO: 0
-    enableSubsurfaceScattering: 0
-    enableTransmission: 0
-    enableAtmosphericScattering: 0
-    enableVolumetrics: 0
-    enableReprojectionForVolumetrics: 0
-    enableLightLayers: 0
-    enableExposureControl: 1
-    diffuseGlobalDimmer: 0
-    specularGlobalDimmer: 0
-    shaderLitMode: 0
-    enableDepthPrepassWithDeferredRendering: 0
-    enableTransparentPrepass: 0
-    enableMotionVectors: 0
-    enableObjectMotionVectors: 0
-    enableDecals: 0
-    enableRoughRefraction: 0
-    enableTransparentPostpass: 0
-    enableDistortion: 0
-    enablePostprocess: 0
-    enableOpaqueObjects: 0
-    enableTransparentObjects: 0
-    enableRealtimePlanarReflection: 0
-    enableMSAA: 0
-    enableAsyncCompute: 0
-    runLightListAsync: 0
-    runSSRAsync: 0
-    runSSAOAsync: 0
-    runContactShadowsAsync: 0
-    runVolumeVoxelizationAsync: 0
-    lightLoopSettings:
-      overrides: 0
-      enableDeferredTileAndCluster: 0
-      enableComputeLightEvaluation: 0
-      enableComputeLightVariants: 0
-      enableComputeMaterialVariants: 0
-      enableFptlForForwardOpaque: 0
-      enableBigTilePrepass: 0
-      isFptlEnabled: 0
-  clearColorMode: 0
-  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
-  clearDepth: 1
-  volumeLayerMask:
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1
-  volumeAnchorOverride: {fileID: 0}
-  antialiasing: 0
-  SMAAQuality: 2
-  dithering: 0
-  stopNaNs: 0
-  taaSharpenStrength: 0.5
-  TAAQuality: 1
-  taaHistorySharpening: 0.35
-  taaAntiFlicker: 0.5
-  taaMotionVectorRejection: 0
-  taaAntiHistoryRinging: 0
-  physicalParameters:
-    m_Iso: 200
-    m_ShutterSpeed: 0.005
-    m_Aperture: 16
-    m_BladeCount: 5
-    m_Curvature: {x: 2, y: 11}
-    m_BarrelClipping: 0.25
-    m_Anamorphism: 0
-  flipYMode: 0
-  xrRendering: 1
-  fullscreenPassthrough: 0
-  allowDynamicResolution: 0
-  customRenderingSettings: 0
-  invertFaceCulling: 0
-  probeLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  hasPersistentHistory: 0
-  exposureTarget: {fileID: 0}
-  m_RenderingPathCustomFrameSettings:
-    bitDatas:
-      data1: 72198262773251917
-      data2: 13763000468760363032
-    lodBias: 1
-    lodBiasMode: 0
-    lodBiasQualityLevel: 0
-    maximumLODLevel: 0
-    maximumLODLevelMode: 0
-    maximumLODLevelQualityLevel: 0
-    sssQualityMode: 0
-    sssQualityLevel: 0
-    sssCustomSampleBudget: 20
-    materialQuality: 0
-  renderingPathCustomFrameSettingsOverrideMask:
-    mask:
-      data1: 0
-      data2: 0
-  defaultFrameSettings: 0
---- !u!1 &7800869322880189811
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7800869322880189814}
-  - component: {fileID: 7800869322880189800}
-  - component: {fileID: 7800869322880189815}
-  m_Layer: 0
-  m_Name: CameraSensor
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7800869322880189814
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7800869322880189811}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 8618870265807608092}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7800869322880189800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7800869322880189811}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c65d1fdc35027290e9b91e2c6ecab1fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  publishHz: 10
-  imageOnGui:
-    show: 1
-    scale: 4
-    xAxis: 0
-    yAxis: 0
-  cameraParameters:
-    width: 1920
-    height: 1080
-    fx: 0
-    fy: 0
-    cx: 0
-    cy: 0
-    k1: 0
-    k2: 0
-    p1: 0
-    p2: 0
-    k3: 0
-  cameraObject: {fileID: 1748890876559847002}
-  distortionShader: {fileID: 7200000, guid: 8ba118ba5fd3df74da56fc7b5c68f16c, type: 3}
-  rosImageShader: {fileID: 7200000, guid: ec3733322406d6750a0ad58713c14110, type: 3}
---- !u!114 &7800869322880189815
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7800869322880189811}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ecaa6f04f76012cce9743315c68a4a83, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  imageTopic: /sensing/camera/traffic_light/image_raw
-  cameraInfoTopic: /sensing/camera/traffic_light/camera_info
-  frameId: traffic_light_left_camera/camera_optical_link
-  qosSettings:
-    ReliabilityPolicy: 2
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2

--- a/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
+++ b/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
@@ -590,7 +590,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 2
   m_TargetDisplay: 0
 --- !u!224 &412951386
 RectTransform:
@@ -3049,7 +3049,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &890457390 stripped
 MonoBehaviour:
@@ -3062,6 +3062,105 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 830ab73cebda3db4580ebd3ece935931, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &939690760
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 939690764}
+  - component: {fileID: 939690763}
+  - component: {fileID: 939690762}
+  - component: {fileID: 939690761}
+  m_Layer: 5
+  m_Name: CameraOutputCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &939690761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939690760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &939690762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939690760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &939690763
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939690760}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 1
+  m_TargetDisplay: 0
+--- !u!224 &939690764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939690760}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &951655714 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9027057600183560098, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
@@ -3334,7 +3433,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 100, y: 50, z: 0}
 --- !u!114 &1144039543 stripped
 MonoBehaviour:
@@ -3411,7 +3510,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1153401687
 GameObject:
@@ -5510,6 +5609,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5653496621862650956, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: cameraObject
+      value: 
+      objectReference: {fileID: 2465439770829660651}
+    - target: {fileID: 5653496621862650956, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
       propertyPath: imageOnGui.show
       value: 1
       objectReference: {fileID: 0}
@@ -5517,8 +5620,41 @@ PrefabInstance:
       propertyPath: imageOnGui.scale
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 5653496621862650956, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: imageOnGui.height
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 5653496621862650956, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: imageOnGui.xOffset
+      value: 320
+      objectReference: {fileID: 0}
+    - target: {fileID: 5653496621862650956, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: imageOnGui.yOffset
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: height
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: xOffset
+      value: 320
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: yOffset
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: cameraOutputCanvas
+      value: 
+      objectReference: {fileID: 939690763}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+--- !u!20 &2465439770829660651 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 2201806139722535076, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+  m_PrefabInstance: {fileID: 2465439770829660650}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7808269042169720464 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5650763240072318842, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}

--- a/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
+++ b/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
@@ -5394,6 +5394,7 @@ GameObject:
   - component: {fileID: 2122627085}
   - component: {fileID: 2122627084}
   - component: {fileID: 2122627083}
+  - component: {fileID: 2122627088}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -5505,6 +5506,38 @@ Transform:
   m_Father: {fileID: 543989980}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2122627088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122627082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1001 &2465439770829660650
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5642,6 +5675,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
       propertyPath: yOffset
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: startXOffset
+      value: 320
+      objectReference: {fileID: 0}
+    - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
+      propertyPath: startYOffset
       value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 8996813226046187441, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}

--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraRos2Publisher.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraRos2Publisher.cs
@@ -1,7 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using ROS2;
+using UnityEngine;
 
 namespace AWSIM
 {

--- a/Assets/AWSIM/Scripts/UI/UICameraBridge.cs
+++ b/Assets/AWSIM/Scripts/UI/UICameraBridge.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace AWSIM.Scripts.UI
+{
+    public class UICameraBridge : MonoBehaviour
+    {
+        [SerializeField] private Canvas cameraOutputCanvas;
+        [SerializeField] private float xOffset;
+        [SerializeField] private float yOffset;
+        [SerializeField] private float height;
+
+        private RawImage rawImage;
+        private AspectRatioFitter aspectRatioFitter;
+
+        private void Start()
+        {
+            SetupCameraOutput();
+        }
+
+        private void SetupCameraOutput()
+        {
+            var cameraOutput = new GameObject(
+                "CameraOutput",
+                typeof(RectTransform),
+                typeof(CanvasRenderer),
+                typeof(UIInteractionHandler),
+                typeof(RawImage),
+                typeof(AspectRatioFitter));
+
+            cameraOutput.transform.SetParent(cameraOutputCanvas.transform, false);
+
+            // Configure RectTransform for bottom left position with specified offsets
+            var rectTransform = cameraOutput.GetComponent<RectTransform>();
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.anchoredPosition = new Vector2(xOffset, yOffset);
+            // Width will be adjusted by AspectRatioFitter, only set height here
+            rectTransform.sizeDelta = new Vector2(0, height);
+
+            rawImage = cameraOutput.GetComponent<RawImage>();
+            aspectRatioFitter = cameraOutput.GetComponent<AspectRatioFitter>();
+            aspectRatioFitter.aspectMode = AspectRatioFitter.AspectMode.HeightControlsWidth;
+        }
+
+
+        public void RenderCameraToUI(CameraSensor.CameraParameters camParams, Texture camRenderTex)
+        {
+            aspectRatioFitter.aspectRatio = (float)camParams.width / camParams.height;
+            rawImage.rectTransform.sizeDelta = new Vector2(height * aspectRatioFitter.aspectRatio, height);
+            rawImage.texture = camRenderTex;
+        }
+
+        private void OnEnable()
+        {
+            if (rawImage != null)
+                rawImage.gameObject.SetActive(true);
+        }
+
+        private void OnDisable()
+        {
+            if (rawImage != null)
+                rawImage.gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/AWSIM/Scripts/UI/UICameraBridge.cs
+++ b/Assets/AWSIM/Scripts/UI/UICameraBridge.cs
@@ -6,8 +6,8 @@ namespace AWSIM.Scripts.UI
     public class UICameraBridge : MonoBehaviour
     {
         [SerializeField] private Canvas cameraOutputCanvas;
-        [SerializeField] private float xOffset;
-        [SerializeField] private float yOffset;
+        [SerializeField] private float startXOffset;
+        [SerializeField] private float startYOffset;
         [SerializeField] private float height;
 
         private RawImage rawImage;
@@ -34,7 +34,7 @@ namespace AWSIM.Scripts.UI
             var rectTransform = cameraOutput.GetComponent<RectTransform>();
             rectTransform.anchorMin = Vector2.zero;
             rectTransform.anchorMax = Vector2.zero;
-            rectTransform.anchoredPosition = new Vector2(xOffset, yOffset);
+            rectTransform.anchoredPosition = new Vector2(startXOffset, startYOffset);
             // Width will be adjusted by AspectRatioFitter, only set height here
             rectTransform.sizeDelta = new Vector2(0, height);
 
@@ -42,7 +42,6 @@ namespace AWSIM.Scripts.UI
             aspectRatioFitter = cameraOutput.GetComponent<AspectRatioFitter>();
             aspectRatioFitter.aspectMode = AspectRatioFitter.AspectMode.HeightControlsWidth;
         }
-
 
         public void RenderCameraToUI(CameraSensor.CameraParameters camParams, Texture camRenderTex)
         {

--- a/Assets/AWSIM/Scripts/UI/UICameraBridge.cs.meta
+++ b/Assets/AWSIM/Scripts/UI/UICameraBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0883c4f62730bd4c90ee9fc4a26c0c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/UI/UIInteractionHandler.cs
+++ b/Assets/AWSIM/Scripts/UI/UIInteractionHandler.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace AWSIM.Scripts.UI
+{
+    public class UIInteractionHandler : MonoBehaviour, IDragHandler, IPointerDownHandler
+    {
+        private Vector2 initialDragPointOffset;
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            var canvasRectTransform = canvas.GetComponent<RectTransform>();
+
+            // Store the initial offset from the pointer to the object's anchor point in local canvas coordinates
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRectTransform, eventData.position,
+                canvas.worldCamera, out var localPointerPosition);
+            initialDragPointOffset = localPointerPosition - ((RectTransform)transform).anchoredPosition;
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            Canvas canvas = GetComponentInParent<Canvas>();
+            RectTransform canvasRectTransform = canvas.GetComponent<RectTransform>();
+
+            // Convert the current pointer position to local canvas coordinates
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRectTransform, eventData.position,
+                canvas.worldCamera, out var localPointerPosition);
+
+            // Apply the initial offset to keep the drag point consistent
+            ((RectTransform)transform).anchoredPosition = localPointerPosition - initialDragPointOffset;
+        }
+    }
+}

--- a/Assets/AWSIM/Scripts/UI/UIInteractionHandler.cs.meta
+++ b/Assets/AWSIM/Scripts/UI/UIInteractionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a300a68538072145b5d6903dde9e3a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The purpose of this PR is to change the way CameraSensor.cs output rendered on the screen. Right now camera output is being rendered over everything on the screen caused by the way currently implemented. This PR separates the visualization of the camera output from the CameraSensor.cs and changes the way it renders. 
 
### Related links

- https://github.com/autowarefoundation/AWSIM/issues/20

## Tests performed

Successfully tested in the editor. 

## Effects on system behavior
**Minimal.**
Instead of rendering camera outputs directly to the screen, now it renders to the UI components which can be controlled more easily. This PR adds 2 new scripts and a Canvas to the AutowareSimulation.unity scene:

**UICameraBridge.cs:** Handles the connection between CameraSensor and the UI. Responsible for creating UI elements per camera.

**UIInteractionHandler.cs:** Currenty small script which handles the user interaction with the camera output on the screen in runtime. Can be extended later on.

**CameraOutputCanvas:** Ordinary canvas used for parenting the camera outputs created by the UICameraBrıdge. Sorting order can be changed as needed. Currently the order is 1 which is behind the MainMenuCanvas and front of the AutowareCanvas. 

- Added UICameraBridge.cs to CameraSensor.prefab.
- Moved some other scripts to the their respective namespaces.
- Removed unnecessary "#include"s from some scripts.
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/