### PR TITLE
ci(buildtest): use unity license instead

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -27,7 +27,7 @@ jobs:
       env:
         UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-        UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
       with:
         targetPlatform: ${{ matrix.target_platform }}
         unityVersion: ${{ matrix.unity_version }}

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -20,14 +20,14 @@ jobs:
         unity_version:
           - 2021.1.7f1
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v4
       with:
         lfs: true
-    - uses: game-ci/unity-builder@v2
+    - uses: game-ci/unity-builder@v4
       env:
-        UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+        UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
         targetPlatform: ${{ matrix.target_platform }}
         unityVersion: ${{ matrix.unity_version }}


### PR DESCRIPTION
## Description

Based on here: https://game.ci/docs/github/builder/

Update the workflow to use the license instead of serial.

### Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
