### PR TITLE
docs: change AWSIM related links to Autoware fork

### DIFF
--- a/docs/Components/ScenarioSimulation/SetupUnityProjectForScenarioSimulation/index.md
+++ b/docs/Components/ScenarioSimulation/SetupUnityProjectForScenarioSimulation/index.md
@@ -4,9 +4,9 @@ Below you can find instructions on how to setup the scenario execution using `sc
 The instruction assumes using the Ubuntu OS.
 
 ## Prerequisites
-1. Build Autoware by following ["Build Autoware with `scenario_simulator_v2`" section from the scenario simulator and AWSIM quick start guide](https://tier4.github.io/AWSIM/GettingStarted/UsingOpenSCENARIO)
+1. Build Autoware by following ["Build Autoware with `scenario_simulator_v2`" section from the scenario simulator and AWSIM quick start guide](https://autowarefoundation.github.io/AWSIM/GettingStarted/UsingOpenSCENARIO)
 
-2. Follow [Setup Unity Project tutorial](https://tier4.github.io/AWSIM/GettingStarted/SetupUnityProject/)
+2. Follow [Setup Unity Project tutorial](https://autowarefoundation.github.io/AWSIM/GettingStarted/SetupUnityProject/)
 
 ## Running the demo
 

--- a/docs/Components/ScenarioSimulation/SetupUnityProjectForScenarioSimulation/index.md
+++ b/docs/Components/ScenarioSimulation/SetupUnityProjectForScenarioSimulation/index.md
@@ -6,7 +6,7 @@ The instruction assumes using the Ubuntu OS.
 ## Prerequisites
 1. Build Autoware by following ["Build Autoware with `scenario_simulator_v2`" section from the scenario simulator and AWSIM quick start guide](https://autowarefoundation.github.io/AWSIM/GettingStarted/UsingOpenSCENARIO)
 
-2. Follow [Setup Unity Project tutorial](https://autowarefoundation.github.io/AWSIM/GettingStarted/SetupUnityProject/)
+2. Follow [Setup Unity Project tutorial](../../../GettingStarted/SetupUnityProject/index.md)
 
 ## Running the demo
 

--- a/docs/DeveloperGuide/HowToContribute/index.md
+++ b/docs/DeveloperGuide/HowToContribute/index.md
@@ -8,18 +8,18 @@ Instead, open a discussion in the [Q&A category](https://github.com/autowarefoun
 The trouble shooting page at [AWSIM](../TroubleShooting/index.md) and at [Autoware](https://autowarefoundation.github.io/autoware-documentation/main/support/troubleshooting/) will be also helpful.
 
 ## Issue
-Before you post an issue, please search [Issues](https://github.com/tier4/AWSIM/issues?q=is%3Aissue) and [Discussions Q&A catecory](https://github.com/orgs/autowarefoundation/discussions/categories/q-a) to check if it is not a known issue.
+Before you post an issue, please search [Issues](https://github.com/autowarefoundation/AWSIM/issues?q=is%3Aissue) and [Discussions Q&A catecory](https://github.com/orgs/autowarefoundation/discussions/categories/q-a) to check if it is not a known issue.
 
 [This page](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-repository) is helpful how to create an issue from a repository.
 
 ### Bug report
-If you find a new bug, please create an issue [here](https://github.com/tier4/AWSIM/issues/new?assignees=&labels=&template=bug.yaml)
+If you find a new bug, please create an issue [here](https://github.com/autowarefoundation/AWSIM/issues/new?assignees=&labels=&template=bug.yaml)
 
 ### Feature request
-If you propose a new feature or have an idea, please create an issue [here](https://github.com/tier4/AWSIM/issues/new?assignees=&labels=&template=feature_request.yaml)
+If you propose a new feature or have an idea, please create an issue [here](https://github.com/autowarefoundation/AWSIM/issues/new?assignees=&labels=&template=feature_request.yaml)
 
 ### Task
-If you have plan to contribute AWSIM, please create an issue [here](https://github.com/tier4/AWSIM/issues/new?assignees=&labels=&template=task.yaml).
+If you have plan to contribute AWSIM, please create an issue [here](https://github.com/autowarefoundation/AWSIM/issues/new?assignees=&labels=&template=task.yaml).
 
 ### Question
 - If you need a general support, please open a discussion in the [Q&A category](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
@@ -35,5 +35,5 @@ The following process should be followed:
 
 Please keep the following in mind, while developing new features:
 
-- [Git branching guidelines](https://tier4.github.io/AWSIM/ProjectGuide/GitBranch/)
+- [Git branching guidelines](https://autowarefoundation.github.io/AWSIM/ProjectGuide/GitBranch/)
 - [C# coding convention](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?redirectedfrom=MSDN).

--- a/docs/GettingStarted/QuickStartDemo/index.md
+++ b/docs/GettingStarted/QuickStartDemo/index.md
@@ -119,7 +119,7 @@ To run the simulator, please follow the steps below.
     1. Download `AWSIM_v1.2.0.zip`.
         We don't have a release yet. Please follow the Setup Guide to build the AWSIM binary.
         [Download AWSIM Demo for ubuntu](){.md-button .md-button--primary}
-    
+
     2. Unzip the downloaded file.
 
     3. Make the `AWSIM_v1.2.0.x86_64` file executable.

--- a/docs/GettingStarted/QuickStartDemo/index.md
+++ b/docs/GettingStarted/QuickStartDemo/index.md
@@ -226,7 +226,7 @@ The self-driving simulation demo has been successfully launched!
 
 ## Troubleshooting
 
-In case of any problems with running the sample AWSIM binary with Autoware, start with checking our [Troubleshooting page](https://autowarefoundation.github.io/AWSIM/DeveloperGuide/TroubleShooting/) with the most common problems.
+In case of any problems with running the sample AWSIM binary with Autoware, start with checking our [Troubleshooting page](../../DeveloperGuide/TroubleShooting/index.md) with the most common problems.
 
 ## Appendix
 - [AWSIM ROS2 topic list](../../Components/ROS2/ROS2TopicList/index.md)

--- a/docs/GettingStarted/QuickStartDemo/index.md
+++ b/docs/GettingStarted/QuickStartDemo/index.md
@@ -117,9 +117,9 @@ To run the simulator, please follow the steps below.
 3. Download and Run AWSIM Demo binary.
 
     1. Download `AWSIM_v1.2.0.zip`.
-
-        [Download AWSIM Demo for ubuntu](https://github.com/tier4/AWSIM/releases/download/v1.2.0/AWSIM_v1.2.0.zip){.md-button .md-button--primary}
-
+        We don't have a release yet. Please follow the Setup Guide to build the AWSIM binary.
+        [Download AWSIM Demo for ubuntu](){.md-button .md-button--primary}
+    
     2. Unzip the downloaded file.
 
     3. Make the `AWSIM_v1.2.0.x86_64` file executable.
@@ -151,7 +151,7 @@ In order to configure and run the Autoware software with the AWSIM demo, please:
 
 1. Download `map files (pcd, osm)` and unzip them.
 
-    [Download Map files (pcd, osm)](https://github.com/tier4/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip){.md-button .md-button--primary}
+    [Download Map files (pcd, osm)](https://drive.google.com/drive/folders/15D5s2m3A7_wtCPio8ewRy0wL_xQtmqss){.md-button .md-button--primary}
 
 2. Clone [Autoware](https://github.com/autowarefoundation/autoware) and move to the directory.
 ```
@@ -226,7 +226,7 @@ The self-driving simulation demo has been successfully launched!
 
 ## Troubleshooting
 
-In case of any problems with running the sample AWSIM binary with Autoware, start with checking our [Troubleshooting page](https://tier4.github.io/AWSIM/DeveloperGuide/TroubleShooting/) with the most common problems.
+In case of any problems with running the sample AWSIM binary with Autoware, start with checking our [Troubleshooting page](https://autowarefoundation.github.io/AWSIM/DeveloperGuide/TroubleShooting/) with the most common problems.
 
 ## Appendix
 - [AWSIM ROS2 topic list](../../Components/ROS2/ROS2TopicList/index.md)

--- a/docs/GettingStarted/SetupUnityProject/index.md
+++ b/docs/GettingStarted/SetupUnityProject/index.md
@@ -99,7 +99,7 @@ To open the Unity AWSIM project in Unity Editor:
 === "Using Unity Hub"
     1. Make sure you have the AWSIM repository cloned and ROS 2 is not sourced.
         ```
-        git clone git@github.com:tier4/AWSIM.git
+        git clone git@github.com:autowarefoundation/AWSIM.git
         ```
 
     2. Launch UnityHub.

--- a/docs/GettingStarted/UsingOpenSCENARIO/index.md
+++ b/docs/GettingStarted/UsingOpenSCENARIO/index.md
@@ -10,7 +10,7 @@ Below you can find instructions on how to setup the OpenSCENARIO execution using
 The instruction assumes using the Ubuntu OS.
 
 ## Prerequisites
-Follow [Setup Unity Project tutorial](https://tier4.github.io/AWSIM/GettingStarted/SetupUnityProject/)
+Follow [Setup Unity Project tutorial](https://tier4.autowarefoundation.io/AWSIM/GettingStarted/SetupUnityProject/)
 
 ## Build Autoware with `scenario_simulator_v2`
 

--- a/docs/GettingStarted/UsingOpenSCENARIO/index.md
+++ b/docs/GettingStarted/UsingOpenSCENARIO/index.md
@@ -10,7 +10,7 @@ Below you can find instructions on how to setup the OpenSCENARIO execution using
 The instruction assumes using the Ubuntu OS.
 
 ## Prerequisites
-Follow [Setup Unity Project tutorial](https://tier4.autowarefoundation.io/AWSIM/GettingStarted/SetupUnityProject/)
+Follow [Setup Unity Project tutorial](../SetupUnityProject/index.md)
 
 ## Build Autoware with `scenario_simulator_v2`
 

--- a/docs/Introduction/AWSIM/index.md
+++ b/docs/Introduction/AWSIM/index.md
@@ -3,7 +3,7 @@
 <source src="awsim_video.mp4" type="video/mp4">
 </video>
 [*AWSIM*](https://github.com/autowarefoundation/AWSIM) is an open-source simulator made with [*Unity*](https://unity.com/) for autonomous driving research and development.
-It is developed for self-driving software like [*Autoware*](../Autoware/). This simulator aims to bridge the gap between the virtual and real worlds, enabling users to train and evaluate their autonomous systems in a safe and controlled environment before deploying them on real vehicles. It provides a realistic virtual environment for training, testing, and evaluating various aspects of autonomous driving systems. 
+It is developed for self-driving software like [*Autoware*](../Autoware/). This simulator aims to bridge the gap between the virtual and real worlds, enabling users to train and evaluate their autonomous systems in a safe and controlled environment before deploying them on real vehicles. It provides a realistic virtual environment for training, testing, and evaluating various aspects of autonomous driving systems.
 
 *AWSIM* simulates a variety of real-world scenarios, with accurate physics and sensor models. It offers a wide range of sensors, such as: *Cameras*, *GNSS*, *IMU* and  *LiDARs*, allowing developers to simulate their  autonomous vehicle's interactions with the environment accurately. The simulator also models dynamic objects, such as pedestrians, other vehicles, and traffic lights, making it possible to study interactions and decision-making in complex traffic scenarios. This enables the testing and evaluation of perception, planning, and control algorithms under different sensor configurations and scenarios.
 

--- a/docs/Introduction/AWSIM/index.md
+++ b/docs/Introduction/AWSIM/index.md
@@ -2,8 +2,8 @@
 <video width="1920" controls autoplay muted loop>
 <source src="awsim_video.mp4" type="video/mp4">
 </video>
-[*AWSIM*](https://github.com/tier4/AWSIM) is an open-source simulator made with [*Unity*](https://unity.com/) for autonomous driving research and development.
-It is developed for self-driving software like [*Autoware*](../Autoware/). This simulator aims to bridge the gap between the virtual and real worlds, enabling users to train and evaluate their autonomous systems in a safe and controlled environment before deploying them on real vehicles. It provides a realistic virtual environment for training, testing, and evaluating various aspects of autonomous driving systems.
+[*AWSIM*](https://github.com/autowarefoundation/AWSIM) is an open-source simulator made with [*Unity*](https://unity.com/) for autonomous driving research and development. 
+It is developed for self-driving software like [*Autoware*](../Autoware/). This simulator aims to bridge the gap between the virtual and real worlds, enabling users to train and evaluate their autonomous systems in a safe and controlled environment before deploying them on real vehicles. It provides a realistic virtual environment for training, testing, and evaluating various aspects of autonomous driving systems. 
 
 *AWSIM* simulates a variety of real-world scenarios, with accurate physics and sensor models. It offers a wide range of sensors, such as: *Cameras*, *GNSS*, *IMU* and  *LiDARs*, allowing developers to simulate their  autonomous vehicle's interactions with the environment accurately. The simulator also models dynamic objects, such as pedestrians, other vehicles, and traffic lights, making it possible to study interactions and decision-making in complex traffic scenarios. This enables the testing and evaluation of perception, planning, and control algorithms under different sensor configurations and scenarios.
 

--- a/docs/Introduction/AWSIM/index.md
+++ b/docs/Introduction/AWSIM/index.md
@@ -2,7 +2,7 @@
 <video width="1920" controls autoplay muted loop>
 <source src="awsim_video.mp4" type="video/mp4">
 </video>
-[*AWSIM*](https://github.com/autowarefoundation/AWSIM) is an open-source simulator made with [*Unity*](https://unity.com/) for autonomous driving research and development. 
+[*AWSIM*](https://github.com/autowarefoundation/AWSIM) is an open-source simulator made with [*Unity*](https://unity.com/) for autonomous driving research and development.
 It is developed for self-driving software like [*Autoware*](../Autoware/). This simulator aims to bridge the gap between the virtual and real worlds, enabling users to train and evaluate their autonomous systems in a safe and controlled environment before deploying them on real vehicles. It provides a realistic virtual environment for training, testing, and evaluating various aspects of autonomous driving systems. 
 
 *AWSIM* simulates a variety of real-world scenarios, with accurate physics and sensor models. It offers a wide range of sensors, such as: *Cameras*, *GNSS*, *IMU* and  *LiDARs*, allowing developers to simulate their  autonomous vehicle's interactions with the environment accurately. The simulator also models dynamic objects, such as pedestrians, other vehicles, and traffic lights, making it possible to study interactions and decision-making in complex traffic scenarios. This enables the testing and evaluation of perception, planning, and control algorithms under different sensor configurations and scenarios.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,12 @@ AWSIM is the best scene for [Autoware](https://github.com/autowarefoundation/aut
 - Many predefined components included (Vehicle dynamic models, Sensor models, Environment configuration, ROS2 communication, etc)
 - Support for Ubuntu 22.04 and windows10/11
 - ROS2 native communication (humble)
-- [Open sourced](https://github.com/tier4/AWSIM)
+- [Open sourced](https://autowarefoundation.com/tier4/AWSIM)
 - Made with [Unity](https://unity.com/)
 
 ## Try the simulation demo yourself!
-
-[Download AWSIM Demo for Ubuntu](https://github.com/tier4/AWSIM/releases/download/v1.2.0/AWSIM_v1.2.0.zip){.md-button .md-button--primary}
+We don't have a release yet. Please build it from the source.
+[Download AWSIM Demo for Ubuntu](https://github.com/autowarefoundation/AWSIM/releases/download/v1.2.0/AWSIM_v1.2.0.zip){.md-button .md-button--primary}
 
 
 To test the AWSIM demo with Autoware please refer to the [Quick start demo](./GettingStarted/QuickStartDemo/index.md) section.


### PR DESCRIPTION
## Description

This PR updates the links referencing "TierIV AWSIM" in documentations to "Autoware AWSIM".

### Related links

- https://github.com/autowarefoundation/AWSIM/issues/16

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
