### PR TITLE
feat: enable side lidars and adjust positions

### DIFF
--- a/Assets/AWSIM/Prefabs/Vehicles/Lexus RX450h 2015 Sample Sensor.prefab
+++ b/Assets/AWSIM/Prefabs/Vehicles/Lexus RX450h 2015 Sample Sensor.prefab
@@ -2398,7 +2398,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4351695443148624285
 Transform:
   m_ObjectHideFlags: 0
@@ -2408,7 +2408,7 @@ Transform:
   m_GameObject: {fileID: 6554901054073138485}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.56362, y: -0.30555, z: 0}
+  m_LocalPosition: {x: 0.59, y: -0.30555, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2598,7 +2598,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2086001783945006568
 Transform:
   m_ObjectHideFlags: 0
@@ -2608,7 +2608,7 @@ Transform:
   m_GameObject: {fileID: 6788859865555044665}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.56362, y: -0.30555, z: 0}
+  m_LocalPosition: {x: -0.59, y: -0.30555, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
## Description

Enabled side lidars on the Lexus by default and adjusted positions slightly
### Related links
Related Issue:
- https://github.com/autowarefoundation/AWSIM/issues/51

Related PR:
- https://github.com/autowarefoundation/autoware_individual_params/pull/47

## Tests performed

I've tested autonomous driving in Nishishinjuku environment with the side/top lidars enabled with the new configuration.

## Effects on system behavior

No effect.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
