### PR TITLE
fix: null reference errors

### DIFF
--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using Unity.VisualScripting;
 using UnityEditor;
 using UnityEngine;
 

--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
@@ -48,6 +48,7 @@ namespace AWSIM.TrafficSimulation
             {
                 if (lane == null)
                 {
+                    Debug.LogWarning("NullReferenceException! Please check Traffic Editor's RightOfWay fields for empty values.");
                     continue;
                 }
 

--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
@@ -48,7 +48,7 @@ namespace AWSIM.TrafficSimulation
             {
                 if (lane == null)
                 {
-                    Debug.LogWarning("NullReferenceException! Please check Traffic Editor's RightOfWay fields for empty values.");
+                    Debug.LogWarning("NullReferenceException! Please check TrafficLaneEditor.cs's RightOfWay fields for empty values.");
                     continue;
                 }
 

--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/TrafficLaneEditor.cs
@@ -48,6 +48,11 @@ namespace AWSIM.TrafficSimulation
 
             foreach (var lane in trafficLane.RightOfWayLanes)
             {
+                if (lane == null)
+                {
+                    continue;
+                }
+
                 Gizmos.DrawSphere(lane.Waypoints[0], 0.4f);
                 for (int i = 1; i < lane.Waypoints.Length; ++i)
                 {
@@ -136,6 +141,7 @@ namespace AWSIM.TrafficSimulation
                         if (isInRightSide)
                             return false;
                     }
+
                     if (AreSameNextLanes(lane, other))
                         return true;
 
@@ -188,11 +194,11 @@ namespace AWSIM.TrafficSimulation
 
         private static bool Intersects(Vector3 p1, Vector3 p2, Vector3 q1, Vector3 q2)
         {
-            return AreLeftOrder(p1, q1, q2) != AreLeftOrder(p2, q1, q2) && AreLeftOrder(p1, p2, q1) != AreLeftOrder(p1, p2, q2);
+            return AreLeftOrder(p1, q1, q2) != AreLeftOrder(p2, q1, q2) &&
+                   AreLeftOrder(p1, p2, q1) != AreLeftOrder(p1, p2, q2);
 
             static bool AreLeftOrder(Vector3 p, Vector3 q, Vector3 r)
                 => (r.z - p.z) * (q.x - p.x) >= (q.z - p.z) * (r.x - p.x);
-
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes null reference exception errors when selecting the scene prefab. 
Caused by TrafficLaneEditor.cs.
Added a null check as a fix.
### Related links

- https://github.com/autowarefoundation/AWSIM/issues/77

## Tests performed

Tested in editor.
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
