### PR TITLE
fix: snap BEV camera on switch

### DIFF
--- a/Assets/AWSIM/Scripts/UI/BirdEyeView.cs
+++ b/Assets/AWSIM/Scripts/UI/BirdEyeView.cs
@@ -37,7 +37,7 @@ namespace AWSIM.Scripts.UI
         private void Start()
         {
             // Find the camera follow target
-            _willFollowEgo = false;
+            _willFollowEgo = true;
             _vehicleTransform = GameObject.FindWithTag("Ego");
             foreach (Transform tf in _vehicleTransform.transform)
             {


### PR DESCRIPTION
## Description

Snaps the bird eye view camera to the ego vehicle when switching mode.

### Related links

- https://github.com/autowarefoundation/AWSIM-Labs/issues/103

## Tests performed

Tested in Unity editor.

## Effects on system behavior

None.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
