### PR TITLE
fix: lidar simulation timer synchronization

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -218,6 +218,11 @@ namespace RGLUnityPlugin
         public void OnEnable()
         {
             activeSensors.Add(this);
+            // Sync LidarSimulationTimer with the active sensors
+            if (activeSensors.Count > 0)
+            {
+                this.timer = activeSensors[0].timer;
+            }
         }
 
         public void OnDisable()


### PR DESCRIPTION
## Description

Fix for synchronizing lidar simulation timer with other active lidars in the scene when a lidar is toggled.

### Related links

- https://github.com/autowarefoundation/AWSIM-Labs/issues/104
## Tests performed

https://youtu.be/NL3mylAa7zI

Tested in editor.
Tested with binary + Autoware.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
