### PR TITLE
fix: vehicle initial gear

### DIFF
--- a/Assets/AWSIM/Scripts/Vehicles/VPP Integration/AutowareVPPAdapter.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VPP Integration/AutowareVPPAdapter.cs
@@ -30,7 +30,7 @@ namespace AWSIM.Scripts.Vehicles.VPP_Integration
         public float SteeringTireRotationRateInput { get; set; }
 
         // Gear input from Autoware
-        [NonSerialized] public Gearbox.AutomaticGear AutomaticShiftInput;
+        [NonSerialized] public Gearbox.AutomaticGear AutomaticShiftInput = Gearbox.AutomaticGear.P;
         private Gearbox.AutomaticGear _automaticShiftInput => AutomaticShiftInput;
 
         // Signal input from Autoware


### PR DESCRIPTION
## Description

Small fix for setting initial gear of vehicle to `park` 
### Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
