### PR TITLE
fix: add null checks when accessing camera components

### DIFF
--- a/Assets/AWSIM/Scripts/UI/BirdEyeView.cs
+++ b/Assets/AWSIM/Scripts/UI/BirdEyeView.cs
@@ -8,25 +8,21 @@ namespace AWSIM.Scripts.UI
     public class BirdEyeView : MonoBehaviour
     {
         public static event Action<GameObject> OnCameraInitialized;
-        [SerializeField] private float _birdEyeCameraInitialHeight = 200;
+        public static event Action<GameObject> OnCameraDestroyed;
 
+        [SerializeField] private float _birdEyeCameraInitialHeight = 200;
         [SerializeField] private float _cameraOrthographicSizeMinimum = 3;
         [SerializeField] private float _cameraOrthographicSizeMaximum = 150;
-
         [SerializeField] private float _zoomChangeMultiplier = 10f;
         [SerializeField] private float _zoomTime = 0.1f;
-
         [SerializeField] private float _dragPanMultiplier = 0.2f;
-
         [SerializeField] private float _keyPanSpeed = 50f;
         [SerializeField] private float _keyPanLerp = 0.5f;
-
         [SerializeField] private float _targetFollowOffsetX;
         [SerializeField] private float _targetFollowOffsetZ;
 
         private Camera _birdEyeCamera;
         private Camera _vehicleCamera;
-
         private Transform _cameraFollowTarget;
         private GameObject _vehicleTransform;
 
@@ -57,6 +53,15 @@ namespace AWSIM.Scripts.UI
 
             // Add to the list of cameras for GraphicsSettings
             OnCameraInitialized?.Invoke(_birdEyeCamera.gameObject);
+        }
+
+        private void OnDestroy()
+        {
+            // Remove the camera from the list of cameras for GraphicsSettings
+            if (_birdEyeCamera != null)
+            {
+                OnCameraDestroyed?.Invoke(_birdEyeCamera.gameObject);
+            }
         }
 
         public void Activate()

--- a/Assets/AWSIM/Scripts/UI/GraphicsSettings.cs
+++ b/Assets/AWSIM/Scripts/UI/GraphicsSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -141,27 +140,33 @@ namespace AWSIM.Scripts.UI
             // update camera parameters
             foreach (var cam in _cameraObjectsList)
             {
-                cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
-                cam.TryGetComponent<Volume>(out var cameraVolume);
-                var cameraVolumeProfile = cameraVolume.profile;
-
-                cameraData.antialiasing = AntialiasingMode.None;
-                cameraData.renderPostProcessing = false;
-                cameraData.renderShadows = false;
-                cameraData.allowHDROutput = false;
-
-                if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                if (cam)
                 {
-                    bloom.active = false;
-                }
+                    cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
+                    cam.TryGetComponent<Volume>(out var cameraVolume);
+                    var cameraVolumeProfile = cameraVolume.profile;
 
-                if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
-                {
-                    tonemapping.active = false;
+                    cameraData.antialiasing = AntialiasingMode.None;
+                    cameraData.renderPostProcessing = false;
+                    cameraData.renderShadows = false;
+                    cameraData.allowHDROutput = false;
+
+                    if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                    {
+                        bloom.active = false;
+                    }
+
+                    if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
+                    {
+                        tonemapping.active = false;
+                    }
                 }
             }
 
-            _sunSource.shadows = LightShadows.Hard;
+            if (_sunSource)
+            {
+                _sunSource.shadows = LightShadows.Hard;
+            }
         }
 
         private void GraphicsMediumQuality()
@@ -173,29 +178,35 @@ namespace AWSIM.Scripts.UI
             // update camera and volume parameters
             foreach (var cam in _cameraObjectsList)
             {
-                cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
-                cam.TryGetComponent<Volume>(out var cameraVolume);
-                var cameraVolumeProfile = cameraVolume.profile;
-
-                cameraData.antialiasing = AntialiasingMode.FastApproximateAntialiasing;
-                cameraData.antialiasingQuality = AntialiasingQuality.Medium;
-                cameraData.renderPostProcessing = true;
-                cameraData.renderShadows = true;
-                cameraData.allowHDROutput = false;
-
-                if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                if (cam)
                 {
-                    bloom.active = false;
-                    bloom.intensity.value = 0.25f;
-                }
+                    cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
+                    cam.TryGetComponent<Volume>(out var cameraVolume);
+                    var cameraVolumeProfile = cameraVolume.profile;
 
-                if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
-                {
-                    tonemapping.active = false;
+                    cameraData.antialiasing = AntialiasingMode.FastApproximateAntialiasing;
+                    cameraData.antialiasingQuality = AntialiasingQuality.Medium;
+                    cameraData.renderPostProcessing = true;
+                    cameraData.renderShadows = true;
+                    cameraData.allowHDROutput = false;
+
+                    if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                    {
+                        bloom.active = false;
+                        bloom.intensity.value = 0.25f;
+                    }
+
+                    if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
+                    {
+                        tonemapping.active = false;
+                    }
                 }
             }
 
-            _sunSource.shadows = LightShadows.Hard;
+            if (_sunSource)
+            {
+                _sunSource.shadows = LightShadows.Hard;
+            }
         }
 
         private void GraphicsHighQuality()
@@ -207,32 +218,38 @@ namespace AWSIM.Scripts.UI
             // update camera parameters
             foreach (var cam in _cameraObjectsList)
             {
-                cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
-                cam.TryGetComponent<Volume>(out var cameraVolume);
-                var cameraVolumeProfile = cameraVolume.profile;
-
-                cameraData.antialiasing = AntialiasingMode.SubpixelMorphologicalAntiAliasing;
-                cameraData.antialiasingQuality = AntialiasingQuality.High;
-                cameraData.renderPostProcessing = true;
-                cameraData.renderShadows = true;
-                cameraData.allowHDROutput = true;
-
-                if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                if (cam)
                 {
-                    bloom.active = true;
-                    bloom.intensity.value = 0.5f;
-                    bloom.highQualityFiltering.overrideState = false;
-                    bloom.highQualityFiltering.value = false;
-                }
+                    cam.TryGetComponent<UniversalAdditionalCameraData>(out var cameraData);
+                    cam.TryGetComponent<Volume>(out var cameraVolume);
+                    var cameraVolumeProfile = cameraVolume.profile;
 
-                if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
-                {
-                    tonemapping.active = true;
-                    tonemapping.mode.value = TonemappingMode.ACES;
+                    cameraData.antialiasing = AntialiasingMode.SubpixelMorphologicalAntiAliasing;
+                    cameraData.antialiasingQuality = AntialiasingQuality.High;
+                    cameraData.renderPostProcessing = true;
+                    cameraData.renderShadows = true;
+                    cameraData.allowHDROutput = true;
+
+                    if (cameraVolumeProfile.TryGet(out Bloom bloom))
+                    {
+                        bloom.active = true;
+                        bloom.intensity.value = 0.5f;
+                        bloom.highQualityFiltering.overrideState = false;
+                        bloom.highQualityFiltering.value = false;
+                    }
+
+                    if (cameraVolumeProfile.TryGet(out Tonemapping tonemapping))
+                    {
+                        tonemapping.active = true;
+                        tonemapping.mode.value = TonemappingMode.ACES;
+                    }
                 }
             }
 
-            _sunSource.shadows = LightShadows.Soft;
+            if (_sunSource)
+            {
+                _sunSource.shadows = LightShadows.Soft;
+            }
         }
 
         private void GraphicsUltraQuality()


### PR DESCRIPTION
## Description

Sometimes getting stuck with transition scene panel. It happens from time to time. Caused by `UI/Graphic Settings Panel`'s interaction with the cameras on the scene. 

This PR fixes the issue.  

### Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Tested in the Editor.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
