### PR TITLE
fix: reported velocity in reverse

### DIFF
--- a/Assets/AWSIM/Scripts/Vehicles/VPP Integration/AutowareVPPAdapter.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VPP Integration/AutowareVPPAdapter.cs
@@ -323,7 +323,7 @@ namespace AWSIM.Scripts.Vehicles.VPP_Integration
             VpSteeringReport = _frontWheels[0].steerAngle;
             VpGearReport = _vehicleController.data.bus[Channel.Vehicle][VehicleData.GearboxMode];
             VpVelocityReport =
-                transform.InverseTransformDirection(_rigidbody.velocity.normalized * _vehicleController.speed);
+                transform.InverseTransformDirection(_rigidbody.velocity);
             VpAngularVelocityReport = transform.InverseTransformDirection(AngularVelocity);
             VpThrottleStatusReport =
                 _vehicleController.data.bus[Channel.Input][InputData.Throttle] * VppToAutowareMultiplier;


### PR DESCRIPTION
## Description

Update reported velocity form the AWSIM side. It was reporting positive values while the vehicle is moving backwards. This pr fixes it.

### Related links

- https://github.com/autowarefoundation/AWSIM-Labs/issues/165

## Tests performed

Tested in Editor. 

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
